### PR TITLE
Typo in linestyle in the matplotlib example.

### DIFF
--- a/2--The Python world of science and data.ipynb
+++ b/2--The Python world of science and data.ipynb
@@ -965,7 +965,7 @@
    "source": [
     "pyplot.plot(xarray,yarray,color='k',linestyle='-', label='square')\n",
     "pyplot.plot(xarray,zarray,color='k',linestyle='--', label='cube')\n",
-    "pyplot.plot(xarray,warray,color='k',llinestyle=':', label='square root')\n",
+    "pyplot.plot(xarray,warray,color='k',linestyle=':', label='square root')\n",
     "pyplot.legend(loc='best')\n",
     "pyplot.show()"
    ]


### PR DESCRIPTION
Thanks to your binder setup I tried running and came across a typo. I thought I may as well fix it while I I was there. Thanks -- this looks like a useful introductory tutorial btw.
